### PR TITLE
fix: 🐛 FastAPI 빌드파일 소스 경로 수정

### DIFF
--- a/.github/workflows/fastapi-cicd.yml
+++ b/.github/workflows/fastapi-cicd.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: "3.13"
 
       - name: 📦 Zip project files
-        run: zip -r ./$GITHUB_SHA.zip .
+        run: zip -r ./$GITHUB_SHA.zip backend/fastapi/
 
       - name: 🌎 Access to AWS
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
### 트러블슈팅
CodeDeploy Agent가 S3로부터 내려받은 zip 파일에서 `appspec.yml` 파일을 찾지 못함
<img width="1027" height="472" alt="image" src="https://github.com/user-attachments/assets/cca776c2-197f-4000-9e56-00220ec80ea5" />

### 원인
업로드된 zip 파일에 `backend/fastapi` 폴더만 있어야 하는데 프로젝트 전체가 압축되어 있었음
<img width="739" height="267" alt="image" src="https://github.com/user-attachments/assets/9dff6c60-daf9-4f17-b9fe-b0c94a2efde7" />

### 해결
workflow 파일에서 압축 대상 경로 수정
<img width="888" height="180" alt="image" src="https://github.com/user-attachments/assets/d984569f-dc79-436e-b475-a4d9cd2373a1" />
