### PR TITLE
fix: 🐛 Safari에서 날짜 포맷 인식하지 못하여 발생하는 Invalid Date 오류 수정

### DIFF
--- a/frontend/src/utils/utils-datetime.ts
+++ b/frontend/src/utils/utils-datetime.ts
@@ -9,10 +9,7 @@ export const calcElaspedTime = (datetime: number): string => {
   if (minutes < 60) return `${Math.floor(minutes)}분`;
 
   const hours = minutes / 60;
-  if (hours < 24)
-    return `${Math.floor(hours)}시간 ${Math.floor(
-      minutes - Math.floor(hours) * 60
-    )}분`;
+  if (hours < 24) return `${Math.floor(hours)}시간 ${Math.floor(minutes - Math.floor(hours) * 60)}분`;
 
   const days = hours / 24;
   if (days) return `${Math.floor(days)}일`;
@@ -22,10 +19,7 @@ export const calcElaspedTime = (datetime: number): string => {
 
 /** yyyyMMddHHmmss 포맷의 시간을 밀리초 숫자(From 1970-1-1)로 변환 */
 export const yyyyMMddHHmmssToDateTime = (datetime: string): number => {
-  return new Date(
-    datetime.replace(
-      /^(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)$/,
-      "$4:$5:$6 $2/$3/$1"
-    )
-  ).getTime();
+  // Safari 호환을 위해 ISO 8601 형식으로 변환
+  const formatted = datetime.replace(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/, '$1-$2-$3T$4:$5:$6');
+  return new Date(formatted).getTime();
 };


### PR DESCRIPTION
Safari에서 [new Date("17:52:33 09/26/2025")](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) 형식을 인식하지 못해서 발생하는 문제. Safari는 날짜 문자열 파싱이 다른 브라우저보다 엄격함

### 문제 원인
현재 정규식이 "17:52:33 09/26/2025" 형식으로 변환하는데, 이는 Safari에서 유효하지 않은 날짜 형식임

### 해결방법
```ts
/** yyyyMMddHHmmss 포맷의 시간을 밀리초 숫자(From 1970-1-1)로 변환 */
export const yyyyMMddHHmmssToDateTime = (datetime: string): number => {
  // Safari 호환을 위해 ISO 8601 형식으로 변환
  const formatted = datetime.replace(
    /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/,
    "$1-$2-$3T$4:$5:$6"
  );
  return new Date(formatted).getTime();
};
```
기존: "17:52:33 09/26/2025" (Safari에서 인식 불가)
수정: "2025-09-26T17:52:33" (ISO 8601 표준, 모든 브라우저 호환)